### PR TITLE
Fix properties not showing on page

### DIFF
--- a/client/src/pages/Properties.tsx
+++ b/client/src/pages/Properties.tsx
@@ -15,8 +15,12 @@ export default function Properties() {
     queryKey: ['/api/properties'],
     queryFn: async () => {
       const res = await apiRequest('/api/properties')
-      const raw = await res.json() as any[]
-      const mapped: PropertyItem[] = (raw || []).map((p: any) => ({
+      const data = await res.json() as any
+
+      // El endpoint puede devolver { properties: [...] } o directamente un array
+      const raw: any[] = Array.isArray(data) ? data : (data?.properties ?? [])
+
+      const mapped: PropertyItem[] = raw.map((p: any) => ({
         id: String(p.id || p._id || ''),
         title: p.title,
         description: p.description,
@@ -29,6 +33,7 @@ export default function Properties() {
         bathrooms: p.bathrooms,
         featured: Boolean(p.featured)
       }))
+
       return mapped.filter(p => Boolean(p.id))
     }
   })


### PR DESCRIPTION
Fix properties not displaying by updating the API response handling to correctly parse data wrapped in a `properties` object.

Previously, the client assumed the API returned a direct array of properties. This change updates the fetching logic to detect and correctly map properties whether they are a direct array or nested within a `properties` object.

---
<a href="https://cursor.com/background-agent?bcId=bc-287671ac-d3e4-4585-a11a-a4f585824fd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-287671ac-d3e4-4585-a11a-a4f585824fd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

