### PR TITLE
Fix properties not showing on page

### DIFF
--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -13,9 +13,13 @@ export default function Home() {
     queryKey: ['/api/properties'],
     queryFn: async () => {
       const res = await apiRequest('/api/properties')
-      const raw = await res.json() as any[]
+      const data = await res.json() as any
+      
+      // El API ahora devuelve { properties: [...], pagination: {...} }
+      const rawProperties = data.properties || data || []
+      
       // Mapear desde el backend (price, _id) al shape del cliente (priceUsd, id)
-      const mapped: PropertyItem[] = (raw || []).map((p: any) => ({
+      const mapped: PropertyItem[] = (rawProperties || []).map((p: any) => ({
         id: String(p.id || p._id || ''),
         title: p.title,
         description: p.description,

--- a/client/src/pages/Properties.tsx
+++ b/client/src/pages/Properties.tsx
@@ -11,12 +11,16 @@ export default function Properties() {
   const [filters, setFilters] = useState<FiltersState>({ type: 'Todos', order: 'MasNuevo' })
 
   // Usar API para obtener propiedades actualizadas en tiempo real
-  const { data: items = [], isLoading } = useQuery({
+  const { data: items = [], isLoading, error } = useQuery({
     queryKey: ['/api/properties'],
     queryFn: async () => {
       const res = await apiRequest('/api/properties')
-      const raw = await res.json() as any[]
-      const mapped: PropertyItem[] = (raw || []).map((p: any) => ({
+      const data = await res.json() as any
+      
+      // El API ahora devuelve { properties: [...], pagination: {...} }
+      const rawProperties = data.properties || data || []
+      
+      const mapped: PropertyItem[] = (rawProperties || []).map((p: any) => ({
         id: String(p.id || p._id || ''),
         title: p.title,
         description: p.description,
@@ -52,6 +56,10 @@ export default function Properties() {
         {isLoading ? (
           <Col xs={12} className="text-center py-4">
             <p>Cargando propiedades...</p>
+          </Col>
+        ) : error ? (
+          <Col xs={12} className="text-center py-4">
+            <p>Error cargando propiedades: {error.message}</p>
           </Col>
         ) : filtered.length === 0 ? (
           <Col xs={12} className="text-center py-4">

--- a/package-lock.json
+++ b/package-lock.json
@@ -7521,6 +7521,7 @@
     "server": {
       "version": "1.0.0",
       "dependencies": {
+        "cloudinary": "^2.5.1",
         "cors": "^2.8.5",
         "dotenv": "^17.2.2",
         "drizzle-orm": "^0.44.5",

--- a/server/src/config/database.ts
+++ b/server/src/config/database.ts
@@ -5,7 +5,8 @@ const connectDB = async (): Promise<void> => {
     const mongoUri = process.env.MONGO_URI;
     
     if (!mongoUri) {
-      throw new Error('MONGO_URI no está definida en las variables de entorno');
+      console.log('⚠️  MONGO_URI no está definida - funcionando en modo JSON fallback');
+      return; // No lanzar error, solo retornar
     }
 
     console.log('Conectando a MongoDB...');
@@ -34,7 +35,13 @@ const connectDB = async (): Promise<void> => {
       });
     }
     
-    // Salir del proceso si no se puede conectar a la BD
+    // En desarrollo, no salir del proceso para permitir funcionar con JSON
+    if (process.env.NODE_ENV !== 'production') {
+      console.log('🔄 Continuando en modo JSON fallback');
+      return;
+    }
+    
+    // Solo en producción salir del proceso
     process.exit(1);
   }
 };


### PR DESCRIPTION
Implement a JSON data fallback for property API endpoints and update the frontend to correctly parse the API response, ensuring properties display even without a MongoDB connection.

The original issue was that properties were not displayed due to a missing MongoDB configuration and a mismatch in the API response structure expected by the frontend. This PR introduces a fallback mechanism to serve properties from a local JSON file when MongoDB is unavailable and adjusts the frontend to correctly handle the paginated API response format.

---
<a href="https://cursor.com/background-agent?bcId=bc-5b997e70-64a4-49d1-adec-9025295e1153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5b997e70-64a4-49d1-adec-9025295e1153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

